### PR TITLE
Add voperson schema translation compatible with 389 DS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * [voPerson Object Class and Recommendations](voPerson.md)
 * OpenLDAP Schema Files, in [schema](schema/openldap/voperson.schema) and [ldif](schema/openldap/voperson.ldif) formats
+* 389 DS [Schema File](schema/389-ds/voperson.ldif) 
 
 Please record comments and suggestions in the [issue tracker](https://github.com/voperson/voperson/issues).
 

--- a/schema/389-ds/voperson.ldif
+++ b/schema/389-ds/voperson.ldif
@@ -1,0 +1,66 @@
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+cn: schema
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.1 
+        NAME 'voPersonApplicationUID' 
+        DESC 'voPerson Application-Specific User Identifier' 
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.2 
+        NAME 'voPersonAuthorName' 
+        DESC 'voPerson Author Name' 
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.3 
+        NAME 'voPersonCertificateDN'
+        DESC 'voPerson Certificate Distinguished Name' 
+        EQUALITY distinguishedNameMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.4 
+        NAME 'voPersonCertificateIssuerDN' 
+        DESC 'voPerson Certificate Issuer DN' 
+        EQUALITY distinguishedNameMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.5 
+        NAME 'voPersonExternalID' 
+        DESC 'voPerson Scoped External Identifier' 
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.6 
+        NAME 'voPersonID' 
+        DESC 'voPerson Unique Identifier' 
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.7 
+        NAME 'voPersonPolicyAgreement' 
+        DESC 'voPerson Policy Agreement Indicator' 
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.8 
+        NAME 'voPersonSoRID' 
+        DESC 'voPerson External Identifier'
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+attributeTypes: ( 1.3.6.1.4.1.34998.3.3.1.9 
+        NAME 'voPersonStatus' 
+        DESC 'voPerson Status' 
+        EQUALITY caseIgnoreMatch 
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+objectClasses: ( 1.3.6.1.4.1.34998.3.3.1 
+        NAME 'voPerson' 
+        AUXILIARY
+        MAY ( voPersonApplicationUID $ voPersonAuthorName $ voPersonCertificateDN $
+              voPersonCertificateIssuerDN $ voPersonExternalID $ voPersonID $
+              voPersonPolicyAgreement $ voPersonSoRID $ voPersonStatus ) )


### PR DESCRIPTION
This is tested to load properly, allow setting voPerson objectClass, and allow setting relevant attributes for object. 